### PR TITLE
[setup] use platform module to reliably indentify implementation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from distutils.core import setup
 from distutils.extension import Extension
-import sys
+import platform
 
-if sys.subversion[0] == 'PyPy':
+if platform.python_implementation() == 'PyPy':
     options = {'py_modules':['numa']}
 else:
     try:


### PR DESCRIPTION
```sys.subversion[0]``` failed on python 3.4 for me. The platform module is the more portable solution.